### PR TITLE
BUGFIX: pubsub subscription should be unique per channelName

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -186,7 +186,7 @@ module.exports = function (uri, options) {
 
           if (channels[channelName]) {
               channels[channelName].unsubscribe();
-              delete channels[channelName]
+              delete channels[channelName];
           }
         } else if (typeof callback === 'function') {
             process.nextTick(callback.bind(null, null));

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -183,6 +183,7 @@ module.exports = function (uri, options) {
 
           if (channels[channelName]) {
               channels[channelName].unsubscribe();
+              delete channels[channelName]
           }
         } else if (typeof callback === 'function') {
             process.nextTick(callback.bind(null, null));

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -155,7 +155,10 @@ module.exports = function (uri, options) {
         Adapter.prototype.add.call(self, clientId, roomName);
         channelName = makeChannelName(self.nsp.name, roomName);
 
-        channels[channelName] = self.channel.subscribe(channelName, self.onmessage.bind(self));
+        if (!channels[channelName]) {
+            channels[channelName] = self.channel.subscribe(channelName, self.onmessage.bind(self));  
+        }
+        
 
         if (typeof callback === 'function') {
             process.nextTick(callback.bind(null, null));


### PR DESCRIPTION
Currently `MongoAdapter.prototype.add()` subscribes the adaptor for every user joining the channel, which is wrong. As a consequence, when multiple users join a room,  `MongoAdapter.prototype.onmessage()` is called for every message - and for every user - causing multiple broadcast of the same message.
